### PR TITLE
flannel: fix mount for /run/flannel

### DIFF
--- a/flannel/Dockerfile
+++ b/flannel/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Giuseppe Scrivano <gscrivan@redhat.com>
 
 RUN dnf install -y flannel && dnf clean all
 
+ADD install.sh /usr/bin/install.sh
+
 COPY config.json.template manifest.json service.template /exports/
 
-CMD ["/usr/bin/flanneld", "-etcd-endpoints=http://127.0.0.1:2379"]
+CMD ["/usr/bin/install.sh", "/usr/bin/flanneld", "-etcd-endpoints=http://127.0.0.1:2379", "-subnet-dir=/run/$NAME/networks", "-subnet-file=/run/$NAME/subnet.env"]

--- a/flannel/config.json.template
+++ b/flannel/config.json.template
@@ -8,12 +8,16 @@
 		"terminal": false,
 		"user": {},
 		"args": [
+                        "/usr/bin/install.sh",
                         "/usr/bin/flanneld",
-                        "-etcd-endpoints=$ETCD_ENDPOINTS"
+                        "-etcd-endpoints=$ETCD_ENDPOINTS",
+                        "-subnet-dir=/run/$NAME/networks",
+                        "-subnet-file=/run/$NAME/subnet.env"
 		],
 		"env": [
 			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-			"TERM=xterm"
+			"TERM=xterm",
+			"NAME=$NAME"
 		],
 		"cwd": "/",
 		"capabilities": [
@@ -141,9 +145,9 @@
 			]
 		},
                 {
-                        "destination": "/run/flannel",
+                        "destination": "/run",
                         "type": "bind",
-                        "source": "/run/$NAME",
+                        "source": "/run",
                         "options": [
                                 "rw",
                                 "rbind",

--- a/flannel/install.sh
+++ b/flannel/install.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ ! -d "/run/$NAME" ]; then
+    mkdir /run/$NAME
+fi
+
+exec $@


### PR DESCRIPTION
Add an extra install script to detect if /run/$NAME exists, where
$NAME is the specified name of the container. If not it will be
created, to prevent runc from complaining.