### PR TITLE
azure: use $DESTDIR

### DIFF
--- a/azure/exports/service.template
+++ b/azure/exports/service.template
@@ -4,11 +4,13 @@ Wants=network-online.target sshd.service sshd-keygen.service
 After=network-online.target
 
 [Service]
-ExecStart=/usr/bin/python  -u /usr/sbin/waagent -daemon
+Environment=PYTHONPATH=$DESTDIR/rootfs/usr/lib/python2.7/site-packages/
+Environment=WALA_ROOT=$DESTDIR/rootfs
+ExecStart=/usr/bin/python  -u usr/sbin/waagent -daemon
 Restart=always
 RestartSec=5
-WorkingDirectory=${DESTDIR}/rootfs
-RuntimeDirectory=${NAME}
+WorkingDirectory=/var/lib/containers/atomic/wala-container.0/rootfs
 
 [Install]
 WantedBy=multi-user.target
+


### PR DESCRIPTION
azure: use destdir and WALA_ROOT
    
When defining environment variables, use the DESTDIR variable
instead of static, fq-names.  Alse, define WALA_ROOT for use
with the agent when in a system_container.
