### PR TITLE
Bind /dev/disk to node and master

### DIFF
--- a/kubernetes-apiserver/config.json.template
+++ b/kubernetes-apiserver/config.json.template
@@ -147,6 +147,16 @@
             ]
          },
          {
+            "type": "bind",
+            "source": "/dev/disk",
+            "destination": "/dev/disk",
+            "options": [
+                "rbind",
+                "ro",
+                "rprivate"
+            ]
+         },
+         {
             "destination": "/etc/resolv.conf",
             "type": "bind",
             "source": "/etc/resolv.conf",

--- a/kubernetes-controller-manager/config.json.template
+++ b/kubernetes-controller-manager/config.json.template
@@ -147,6 +147,16 @@
             ]
          },
          {
+            "type": "bind",
+            "source": "/dev/disk",
+            "destination": "/dev/disk",
+            "options": [
+                "rbind",
+                "ro",
+                "rprivate"
+            ]
+         },
+         {
             "destination": "/etc/resolv.conf",
             "type": "bind",
             "source": "/etc/resolv.conf",

--- a/kubernetes-kubelet/config.json.template
+++ b/kubernetes-kubelet/config.json.template
@@ -296,6 +296,16 @@
             ]
          },
          {
+            "type": "bind",
+            "source": "/dev/disk",
+            "destination": "/dev/disk",
+            "options": [
+                "rbind",
+                "ro",
+                "rprivate"
+            ]
+         },
+         {
            "type": "bind",
            "source": "/etc/localtime",
            "destination": "/etc/localtime",


### PR DESCRIPTION
When kubernetes openstack cloud provider get vm metadata by
configdriver, it get vm info from '/dev/disk/*', so we should bind
'/dev/disk' for kube-apiserver kube-controller-manager and kubelet.

Fix #171
cc @strigazi